### PR TITLE
Prepare repo for archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-You can use this GitHub App template code as a foundation to create any GitHub App you'd like. You can learn how to configure a template GitHub App by following the "[Setting up your development environment](https://developer.github.com/apps/quickstart-guides/setting-up-your-development-environment/)" quickstart guide on developer.github.com.
+⚠️ Note: This repository is not maintained. For more recent guides about how to build GitHub Apps, see "[About writing code for a GitHub App](https://docs.github.com/en/apps/creating-github-apps/writing-code-for-a-github-app/about-writing-code-for-a-github-app)."
+
+You can use this GitHub App template code as a foundation to create any GitHub App you'd like. You can learn how to configure a template GitHub App by following the archived "[Setting up your development environment](https://web.archive.org/web/20230604175646/https://docs.github.com/en/apps/creating-github-apps/writing-code-for-a-github-app/setting-up-your-development-environment-to-create-a-github-app)" guide.
 
 ## Install
 


### PR DESCRIPTION
We have new tutorials to help users build GitHub Apps:

- [Building a GitHub App that responds to webhook events](https://docs.github.com/en/apps/creating-github-apps/guides/building-a-github-app-that-responds-to-webhook-events): covers webhooks + installation access token
- [Building a CLI with a GitHub App](https://docs.github.com/en/apps/creating-github-apps/guides/building-a-cli-with-a-github-app): covers device flow + user access token
- [Building a "Login with GitHub" button with a GitHub App](https://docs.github.com/en/apps/creating-github-apps/guides/building-a-login-with-github-button-with-a-github-app): covers web app flow + user access token
- [Quickstart](https://docs.github.com/en/apps/creating-github-apps/guides/quickstart)

The old article that this repo accompanies covers similar info, but links out for a lot of info, some of which is outdated or no longer relevant. Additionally, this reference repo is unmaintained.

This PR updates the README to point users to the newer tutorials and to link to the archived version of the article that accompanies this repo.